### PR TITLE
fix bug with logging exception

### DIFF
--- a/sgr_deep_research/api/endpoints.py
+++ b/sgr_deep_research/api/endpoints.py
@@ -93,7 +93,7 @@ async def provide_clarification(agent_id: str, request: ChatCompletionRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Error completion: {e}")
-        raise HTTPException(status_code=500, detail="str(e)")
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @app.post("/v1/chat/completions")
@@ -128,4 +128,4 @@ async def create_chat_completion(request: ChatCompletionRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Error completion: {e}")
-        raise HTTPException(status_code=500, detail="str(e)")
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
Problem:

When an unexpected Exception occurred in the /v1/provide-clarification and /v1/chat/completions endpoints, the API returned the static string "str(e)" in the detail field instead of the real error message.

Solution:

This change corrects the HTTPException call to properly convert the exception e to a string using str(e). This allows the actual cause of the error to be visible on the client side, which simplifies debugging.