### PR TITLE
FinarAnswerTool should not limit num of completed steps

### DIFF
--- a/sgr_deep_research/core/tools/final_answer_tool.py
+++ b/sgr_deep_research/core/tools/final_answer_tool.py
@@ -24,7 +24,7 @@ class FinalAnswerTool(BaseTool):
 
     reasoning: str = Field(description="Why task is now complete and how answer was verified")
     completed_steps: list[str] = Field(
-        description="Summary of completed steps including verification", min_length=1, max_length=5
+        description="Summary of completed steps including verification", min_length=1
     )
     answer: str = Field(description="Comprehensive final answer with EXACT factual details (dates, numbers, names)")
     status: Literal[AgentStatesEnum.COMPLETED, AgentStatesEnum.FAILED] = Field(description="Task completion status")


### PR DESCRIPTION
See the title. The issue was reproduced on the pipeline with 7 steps. The reporting tool was able to complete though, so it's more about GUI/UX problem - user is not receiving the final answer in the browser.