### PR TITLE
feat: add custom_context field to research context

### DIFF
--- a/sgr_deep_research/core/models.py
+++ b/sgr_deep_research/core/models.py
@@ -61,6 +61,9 @@ class ResearchContext(BaseModel):
     clarification_received: asyncio.Event = Field(
         default_factory=asyncio.Event, description="Event for clarification synchronization"
     )
+    custom_context: dict | BaseModel | None = Field(
+        default=None, description="Custom context for project-specific data"
+    )
 
     def agent_state(self) -> dict:
         return self.model_dump(exclude={"searches", "sources", "clarification_received"})


### PR DESCRIPTION
## Summary
Adds an optional `custom_context` field to the `ResearchContext` class to enable projects extending `sgr_deep_research` to store project-specific data without modifying the core codebase.

## Changes
- Added `custom_context: dict | BaseModel | None` field to `ResearchContext` class in `core/models.py`
- Field is optional with `default=None` for full backward compatibility
- Field description: "Custom context for project-specific data"

## Motivation
This change allows downstream projects to extend `ResearchContext` with custom data structures (e.g., Pydantic models) stored in `custom_context`, enabling project-specific functionality while keeping the core codebase clean and minimal.

## Backward Compatibility
✅ **Fully backward compatible** - the field is optional with `default=None`, so existing code will continue to work without any changes. No breaking changes.

## Use Case Example
from pydantic import BaseModel

class MyProjectContext(BaseModel):
    custom_field: str

context = ResearchContext()
context.custom_context = MyProjectContext(custom_field="value")

## Testing
- ✅ No linter errors
- ✅ Existing functionality remains unchanged
- ✅ Field can be set to `None`, `dict`, or any `BaseModel` instance
