### PR TITLE
Add Langfuse observability integration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,14 @@ SGR__PROMPTS__CLARIFICATION_RESPONSE_FILE=path/to/your/clarification_response.tx
 # =======================================================
 # Note: MCP configuration is complex and better suited for config.yaml
 # See config.yaml.example for MCP server configuration examples
+
+# =======================================================
+# Observability: Langfuse integration
+# =======================================================
+SGR__LANGFUSE=false  # When true, use Langfuse AsyncOpenAI wrapper
+
+# Langfuse client configuration is read by Langfuse SDK itself
+# See: https://langfuse.com/docs/observability/get-started
+#LANGFUSE_SECRET_KEY="sk-lf-xxx"
+#LANGFUSE_PUBLIC_KEY="pk-lf-xxx"
+#LANGFUSE_BASE_URL="http://localhost:3001"

--- a/.env.example
+++ b/.env.example
@@ -54,10 +54,9 @@ SGR__PROMPTS__CLARIFICATION_RESPONSE_FILE=path/to/your/clarification_response.tx
 # =======================================================
 # Observability: Langfuse integration
 # =======================================================
-SGR__LANGFUSE=false  # When true, use Langfuse AsyncOpenAI wrapper
+SGR__LANGFUSE__ENABLED=false
+# SGR__LANGFUSE__PUBLIC_KEY=pk-lf-xxx
+# SGR__LANGFUSE__SECRET_KEY=sk-lf-xxx
+# SGR__LANGFUSE__HOST=http://localhost:3000
 
-# Langfuse client configuration is read by Langfuse SDK itself
-# See: https://langfuse.com/docs/observability/get-started
-#LANGFUSE_SECRET_KEY="sk-lf-xxx"
-#LANGFUSE_PUBLIC_KEY="pk-lf-xxx"
-#LANGFUSE_BASE_URL="http://localhost:3001"
+# Shorthand (credentials via LANGFUSE_* env vars): SGR__LANGFUSE=true

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,8 +12,12 @@ llm:
 
 # Observability (Langfuse)
 # When enabled, AgentFactory will create Langfuse AsyncOpenAI client instead of standard AsyncOpenAI.
-# Langfuse SDK uses LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY and LANGFUSE_BASE_URL environment variables.
-langfuse: false
+# Credentials can be set here or via LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_HOST env vars.
+langfuse:
+  enabled: false
+  # public_key: "pk-lf-xxx"
+  # secret_key: "sk-lf-xxx"
+  # host: "http://localhost:3000"
 
 # Execution Settings
 execution:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,6 +10,11 @@ llm:
   temperature: 0.4  # Temperature (0.0-1.0)
   # proxy: "socks5://127.0.0.1:1081"  # Optional proxy (socks5:// or http://)
 
+# Observability (Langfuse)
+# When enabled, AgentFactory will create Langfuse AsyncOpenAI client instead of standard AsyncOpenAI.
+# Langfuse SDK uses LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY and LANGFUSE_BASE_URL environment variables.
+langfuse: false
+
 # Execution Settings
 execution:
   max_clarifications: 3  # Max clarification requests

--- a/docs/en/framework/configuration.md
+++ b/docs/en/framework/configuration.md
@@ -67,6 +67,41 @@ config = GlobalConfig.from_yaml("config.yaml")
 
 An example can be found in [`config.yaml.example`](https://github.com/vamplabAI/sgr-agent-core/blob/main/config.yaml.example).
 
+### Observability and Langfuse integration
+
+SGR Agent Core can optionally integrate with [Langfuse](https://langfuse.com) for tracing LLM calls.
+This is controlled by the top-level `langfuse` flag in configuration:
+
+```yaml
+llm:
+  api_key: "your-openai-api-key-here"
+  base_url: "https://api.openai.com/v1"
+  model: "gpt-4o-mini"
+  max_tokens: 8000
+  temperature: 0.4
+
+langfuse: false  # default: disabled
+```
+
+The `langfuse` flag can also be set via environment variable:
+
+```bash
+SGR__LANGFUSE=true
+```
+
+When `langfuse` is `true`, `AgentFactory` creates the client using
+`langfuse.openai.AsyncOpenAI` (drop-in replacement for the standard OpenAI client).
+If the `langfuse` package is not installed, the system logs a warning and falls back
+to the standard `openai.AsyncOpenAI` client.
+
+Langfuse itself reads its own environment variables:
+
+- `LANGFUSE_SECRET_KEY`
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_BASE_URL`
+
+See the official Langfuse docs for details on these parameters.
+
 ### Parameter Override
 
 **Key Feature:** `AgentDefinition` inherits all parameters from `GlobalConfig` and overrides only those explicitly specified. This allows creating minimal configurations by specifying only necessary changes.

--- a/docs/en/framework/configuration.md
+++ b/docs/en/framework/configuration.md
@@ -69,40 +69,24 @@ An example can be found in [`config.yaml.example`](https://github.com/vamplabAI/
 
 ### Observability and Langfuse integration
 
-SGR Agent Core can optionally integrate with [Langfuse](https://langfuse.com) for tracing LLM calls.
-Configuration is done via the `langfuse` section in `config.yaml`:
+SGR Agent Core supports optional [Langfuse](https://langfuse.com) integration for LLM tracing:
 
 ```yaml
 langfuse:
   enabled: true
   public_key: "pk-lf-..."
   secret_key: "sk-lf-..."
-  host: "http://localhost:3000"  # omit for cloud.langfuse.com
+  host: "https://cloud.langfuse.com"  # or your self-hosted URL
 ```
 
-The same settings can be passed via environment variables:
-
-```bash
-SGR__LANGFUSE__ENABLED=true
-SGR__LANGFUSE__PUBLIC_KEY=pk-lf-xxx
-SGR__LANGFUSE__SECRET_KEY=sk-lf-xxx
-SGR__LANGFUSE__HOST=http://localhost:3000
-```
-
-**Shorthand** (when credentials are already in `LANGFUSE_*` env vars):
+Shorthand (when credentials are already in `LANGFUSE_*` env vars):
 
 ```yaml
 langfuse: true
 ```
 
-When `langfuse.enabled` is `true`, `AgentFactory` creates the client using
-`langfuse.openai.AsyncOpenAI` (drop-in replacement for the standard OpenAI client).
-If `public_key`/`secret_key`/`host` are provided in config, Langfuse is initialized
-with those credentials explicitly. Otherwise the Langfuse SDK falls back to reading
-`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST` from the environment.
-
-If the `langfuse` package is not installed, the system logs a warning and falls back
-to the standard `openai.AsyncOpenAI` client.
+See the [Langfuse integration guide](langfuse.md) for all connection scenarios
+(Langfuse Cloud, self-hosted, LiteLLM proxy), environment variable reference, and troubleshooting.
 
 ### Parameter Override
 

--- a/docs/en/framework/configuration.md
+++ b/docs/en/framework/configuration.md
@@ -70,37 +70,39 @@ An example can be found in [`config.yaml.example`](https://github.com/vamplabAI/
 ### Observability and Langfuse integration
 
 SGR Agent Core can optionally integrate with [Langfuse](https://langfuse.com) for tracing LLM calls.
-This is controlled by the top-level `langfuse` flag in configuration:
+Configuration is done via the `langfuse` section in `config.yaml`:
 
 ```yaml
-llm:
-  api_key: "your-openai-api-key-here"
-  base_url: "https://api.openai.com/v1"
-  model: "gpt-4o-mini"
-  max_tokens: 8000
-  temperature: 0.4
-
-langfuse: false  # default: disabled
+langfuse:
+  enabled: true
+  public_key: "pk-lf-..."
+  secret_key: "sk-lf-..."
+  host: "http://localhost:3000"  # omit for cloud.langfuse.com
 ```
 
-The `langfuse` flag can also be set via environment variable:
+The same settings can be passed via environment variables:
 
 ```bash
-SGR__LANGFUSE=true
+SGR__LANGFUSE__ENABLED=true
+SGR__LANGFUSE__PUBLIC_KEY=pk-lf-xxx
+SGR__LANGFUSE__SECRET_KEY=sk-lf-xxx
+SGR__LANGFUSE__HOST=http://localhost:3000
 ```
 
-When `langfuse` is `true`, `AgentFactory` creates the client using
+**Shorthand** (when credentials are already in `LANGFUSE_*` env vars):
+
+```yaml
+langfuse: true
+```
+
+When `langfuse.enabled` is `true`, `AgentFactory` creates the client using
 `langfuse.openai.AsyncOpenAI` (drop-in replacement for the standard OpenAI client).
+If `public_key`/`secret_key`/`host` are provided in config, Langfuse is initialized
+with those credentials explicitly. Otherwise the Langfuse SDK falls back to reading
+`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_HOST` from the environment.
+
 If the `langfuse` package is not installed, the system logs a warning and falls back
 to the standard `openai.AsyncOpenAI` client.
-
-Langfuse itself reads its own environment variables:
-
-- `LANGFUSE_SECRET_KEY`
-- `LANGFUSE_PUBLIC_KEY`
-- `LANGFUSE_BASE_URL`
-
-See the official Langfuse docs for details on these parameters.
 
 ### Parameter Override
 

--- a/docs/en/framework/langfuse.md
+++ b/docs/en/framework/langfuse.md
@@ -1,0 +1,176 @@
+# Langfuse Integration
+
+[Langfuse](https://langfuse.com) is an open-source observability platform for LLM applications.
+When enabled, SGR Agent Core wraps the OpenAI client with Langfuse tracing — every LLM call
+is automatically recorded as a trace with inputs, outputs, latency, and token usage.
+
+## Quick Start
+
+Add the `langfuse` block to your `config.yaml`:
+
+```yaml
+langfuse:
+  enabled: true
+  public_key: "pk-lf-..."
+  secret_key: "sk-lf-..."
+  host: "https://cloud.langfuse.com"  # or your self-hosted URL
+```
+
+That's it. On the next agent run you will see traces appearing in the Langfuse UI.
+
+---
+
+## Connection Scenarios
+
+### Option 1: Langfuse Cloud
+
+The simplest option — use the managed service at [cloud.langfuse.com](https://cloud.langfuse.com).
+
+1. Sign up at [cloud.langfuse.com](https://cloud.langfuse.com) and create a project.
+2. Copy **Public Key** and **Secret Key** from *Project Settings → API Keys*.
+3. Add to `config.yaml`:
+
+```yaml
+langfuse:
+  enabled: true
+  public_key: "pk-lf-..."
+  secret_key: "sk-lf-..."
+  host: "https://cloud.langfuse.com"
+```
+
+!!! note
+    `host` defaults to `https://cloud.langfuse.com` in the Langfuse SDK, so you can omit it
+    for the cloud deployment. It is shown here explicitly for clarity.
+
+---
+
+### Option 2: Self-Hosted Langfuse
+
+Run Langfuse on your own infrastructure using the official Docker Compose setup.
+
+1. Follow the [self-hosting guide](https://langfuse.com/docs/deployment/self-host) to start Langfuse locally:
+
+```bash
+git clone https://github.com/langfuse/langfuse.git
+cd langfuse
+docker compose up -d
+```
+
+Langfuse will be available at `http://localhost:3000` by default.
+
+2. Open `http://localhost:3000`, create a project, and copy the API keys.
+
+3. Point SGR at your instance:
+
+```yaml
+langfuse:
+  enabled: true
+  public_key: "pk-lf-..."
+  secret_key: "sk-lf-..."
+  host: "http://localhost:3000"
+```
+
+!!! tip
+    For production deployments, replace `localhost` with the hostname or IP of your Langfuse server
+    (e.g. `https://langfuse.internal.example.com`).
+
+---
+
+### Option 3: Via LiteLLM Proxy
+
+[LiteLLM](https://docs.litellm.ai/) can act as a unified proxy in front of multiple LLM providers
+and forward traces to Langfuse automatically.
+
+**Request flow:**
+
+```
+SGR Agent → LiteLLM Proxy → LLM Provider (OpenAI, etc.)
+                ↓
+            Langfuse
+```
+
+1. Configure LiteLLM to forward traces to Langfuse.
+   In your LiteLLM `config.yaml`, add the Langfuse callback:
+
+```yaml
+# litellm/config.yaml
+litellm_settings:
+  success_callback: ["langfuse"]
+
+environment_variables:
+  LANGFUSE_PUBLIC_KEY: "pk-lf-..."
+  LANGFUSE_SECRET_KEY: "sk-lf-..."
+  LANGFUSE_HOST: "https://cloud.langfuse.com"
+```
+
+2. In SGR's `config.yaml`, point the LLM base URL at your LiteLLM proxy and **disable** the
+   SGR-level Langfuse integration (LiteLLM handles tracing itself):
+
+```yaml
+llm:
+  api_key: "your-litellm-api-key"
+  base_url: "http://localhost:4000"  # LiteLLM proxy address
+  model: "gpt-4o"
+
+langfuse:
+  enabled: false  # LiteLLM handles tracing
+```
+
+!!! note
+    Alternatively, you can enable Langfuse in SGR **and** in LiteLLM at the same time —
+    you will get two levels of tracing (SGR-side LLM calls + LiteLLM-side routing).
+    In most cases, one level is sufficient.
+
+---
+
+## Environment Variables
+
+All `langfuse` config fields can be set via environment variables using the `SGR__LANGFUSE__*`
+prefix:
+
+```bash
+SGR__LANGFUSE__ENABLED=true
+SGR__LANGFUSE__PUBLIC_KEY=pk-lf-xxx
+SGR__LANGFUSE__SECRET_KEY=sk-lf-xxx
+SGR__LANGFUSE__HOST=http://localhost:3000
+```
+
+Alternatively, when credentials are already in native Langfuse environment variables, use the
+shorthand to enable SGR integration without duplicating credentials:
+
+```bash
+# These are read directly by the Langfuse SDK
+LANGFUSE_PUBLIC_KEY=pk-lf-xxx
+LANGFUSE_SECRET_KEY=sk-lf-xxx
+LANGFUSE_HOST=http://localhost:3000
+```
+
+```yaml
+# config.yaml — shorthand, credentials come from LANGFUSE_* env vars
+langfuse: true
+```
+
+!!! warning "Loading `.env` files"
+    Environment variables in `.env` are **not** loaded automatically by Python.
+    SGR's server (`sgr` CLI) loads `.env` on startup via `python-dotenv`.
+    If you run SGR as a library, call `load_dotenv()` yourself before initializing `GlobalConfig`.
+
+---
+
+## Troubleshooting
+
+### `LangfuseImportError` / cannot import `langfuse`
+
+If `langfuse.enabled` is `true` in configuration but the `langfuse` package is not installed
+or cannot be imported, agent startup raises `LangfuseImportError` with a clear message.
+Install the project dependencies (`langfuse` is a core dependency of SGR Agent Core) or
+disable Langfuse by setting `langfuse.enabled` to `false`.
+
+### "Authentication error: Langfuse client initialized without public_key"
+
+The Langfuse SDK cannot find credentials. Check the following:
+
+- `public_key` and `secret_key` are set in `config.yaml` under `langfuse:`, **or**
+  `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` are present in the environment.
+- If using `.env`, make sure the server was started via the `sgr` CLI (which loads `.env`)
+  rather than called directly as a Python module.

--- a/docs/ru/framework/configuration.md
+++ b/docs/ru/framework/configuration.md
@@ -70,40 +70,24 @@ config = GlobalConfig.from_yaml("config.yaml")
 
 ### Наблюдаемость и интеграция с Langfuse
 
-SGR Agent Core может опционально интегрироваться с [Langfuse](https://langfuse.com) для трассировки вызовов LLM.
-Настройка производится через секцию `langfuse` в `config.yaml`:
+SGR Agent Core поддерживает опциональную интеграцию с [Langfuse](https://langfuse.com) для трассировки LLM-вызовов:
 
 ```yaml
 langfuse:
   enabled: true
   public_key: "pk-lf-..."
   secret_key: "sk-lf-..."
-  host: "http://localhost:3000"  # опустите для cloud.langfuse.com
+  host: "https://cloud.langfuse.com"  # или ваш self-hosted URL
 ```
 
-Те же параметры можно задать через переменные окружения:
-
-```bash
-SGR__LANGFUSE__ENABLED=true
-SGR__LANGFUSE__PUBLIC_KEY=pk-lf-xxx
-SGR__LANGFUSE__SECRET_KEY=sk-lf-xxx
-SGR__LANGFUSE__HOST=http://localhost:3000
-```
-
-**Сокращённая форма** (когда ключи уже заданы в `LANGFUSE_*` переменных окружения):
+Сокращённая форма (когда ключи уже заданы в `LANGFUSE_*` env):
 
 ```yaml
 langfuse: true
 ```
 
-Когда `langfuse.enabled` установлен в `true`, `AgentFactory` создаёт клиент на основе
-`langfuse.openai.AsyncOpenAI` (drop-in замена стандартного клиента OpenAI).
-Если в конфиге указаны `public_key`/`secret_key`/`host`, Langfuse инициализируется
-с этими учётными данными явно. В противном случае SDK Langfuse самостоятельно
-читает `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` и `LANGFUSE_HOST` из окружения.
-
-Если пакет `langfuse` не установлен, система пишет предупреждение в лог и
-откатывается к стандартному клиенту `openai.AsyncOpenAI`.
+Подробнее о всех сценариях подключения (Langfuse Cloud, self-hosted, LiteLLM proxy),
+переменных окружения и решении проблем — в [руководстве по интеграции с Langfuse](langfuse.md).
 
 ### Переопределение параметров
 

--- a/docs/ru/framework/configuration.md
+++ b/docs/ru/framework/configuration.md
@@ -68,6 +68,40 @@ config = GlobalConfig.from_yaml("config.yaml")
 Пример можно найти в [`config.yaml.example`](https://github.com/vamplabAI/sgr-agent-core/blob/main/config.yaml.example).
 
 
+### Наблюдаемость и интеграция с Langfuse
+
+SGR Agent Core может опционально интегрироваться с [Langfuse](https://langfuse.com) для трассировки вызовов LLM.
+Управление включением происходит через верхнеуровневый флаг `langfuse` в конфигурации:
+
+```yaml
+llm:
+  api_key: "your-openai-api-key-here"
+  base_url: "https://api.openai.com/v1"
+  model: "gpt-4o-mini"
+  max_tokens: 8000
+  temperature: 0.4
+
+langfuse: false  # по умолчанию отключено
+```
+
+Тот же флаг можно задать через переменную окружения:
+
+```bash
+SGR__LANGFUSE=true
+```
+
+Когда `langfuse` установлен в `true`, `AgentFactory` создает клиент на основе
+`langfuse.openai.AsyncOpenAI` (drop-in замена стандартного клиента OpenAI).
+Если пакет `langfuse` не установлен, система пишет предупреждение в лог и
+откатывается к стандартному клиенту `openai.AsyncOpenAI`.
+
+Сам Langfuse читает свои переменные окружения:
+
+- `LANGFUSE_SECRET_KEY`
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_BASE_URL`
+
+Подробности по этим параметрам см. в официальной документации Langfuse.
 
 ### Переопределение параметров
 

--- a/docs/ru/framework/configuration.md
+++ b/docs/ru/framework/configuration.md
@@ -71,37 +71,39 @@ config = GlobalConfig.from_yaml("config.yaml")
 ### Наблюдаемость и интеграция с Langfuse
 
 SGR Agent Core может опционально интегрироваться с [Langfuse](https://langfuse.com) для трассировки вызовов LLM.
-Управление включением происходит через верхнеуровневый флаг `langfuse` в конфигурации:
+Настройка производится через секцию `langfuse` в `config.yaml`:
 
 ```yaml
-llm:
-  api_key: "your-openai-api-key-here"
-  base_url: "https://api.openai.com/v1"
-  model: "gpt-4o-mini"
-  max_tokens: 8000
-  temperature: 0.4
-
-langfuse: false  # по умолчанию отключено
+langfuse:
+  enabled: true
+  public_key: "pk-lf-..."
+  secret_key: "sk-lf-..."
+  host: "http://localhost:3000"  # опустите для cloud.langfuse.com
 ```
 
-Тот же флаг можно задать через переменную окружения:
+Те же параметры можно задать через переменные окружения:
 
 ```bash
-SGR__LANGFUSE=true
+SGR__LANGFUSE__ENABLED=true
+SGR__LANGFUSE__PUBLIC_KEY=pk-lf-xxx
+SGR__LANGFUSE__SECRET_KEY=sk-lf-xxx
+SGR__LANGFUSE__HOST=http://localhost:3000
 ```
 
-Когда `langfuse` установлен в `true`, `AgentFactory` создает клиент на основе
+**Сокращённая форма** (когда ключи уже заданы в `LANGFUSE_*` переменных окружения):
+
+```yaml
+langfuse: true
+```
+
+Когда `langfuse.enabled` установлен в `true`, `AgentFactory` создаёт клиент на основе
 `langfuse.openai.AsyncOpenAI` (drop-in замена стандартного клиента OpenAI).
+Если в конфиге указаны `public_key`/`secret_key`/`host`, Langfuse инициализируется
+с этими учётными данными явно. В противном случае SDK Langfuse самостоятельно
+читает `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` и `LANGFUSE_HOST` из окружения.
+
 Если пакет `langfuse` не установлен, система пишет предупреждение в лог и
 откатывается к стандартному клиенту `openai.AsyncOpenAI`.
-
-Сам Langfuse читает свои переменные окружения:
-
-- `LANGFUSE_SECRET_KEY`
-- `LANGFUSE_PUBLIC_KEY`
-- `LANGFUSE_BASE_URL`
-
-Подробности по этим параметрам см. в официальной документации Langfuse.
 
 ### Переопределение параметров
 

--- a/docs/ru/framework/langfuse.md
+++ b/docs/ru/framework/langfuse.md
@@ -1,0 +1,178 @@
+# Интеграция с Langfuse
+
+[Langfuse](https://langfuse.com) — open-source платформа для наблюдаемости LLM-приложений.
+При включении SGR Agent Core оборачивает OpenAI-клиент трассировкой Langfuse — каждый вызов
+LLM автоматически записывается как трейс с входными данными, ответом, латентностью и
+количеством токенов.
+
+## Быстрый старт
+
+Добавьте блок `langfuse` в ваш `config.yaml`:
+
+```yaml
+langfuse:
+  enabled: true
+  public_key: "pk-lf-..."
+  secret_key: "sk-lf-..."
+  host: "https://cloud.langfuse.com"  # или ваш self-hosted URL
+```
+
+Готово. При следующем запуске агента трейсы появятся в интерфейсе Langfuse.
+
+---
+
+## Сценарии подключения
+
+### Вариант 1: Langfuse Cloud
+
+Самый простой вариант — использовать облачный сервис [cloud.langfuse.com](https://cloud.langfuse.com).
+
+1. Зарегистрируйтесь на [cloud.langfuse.com](https://cloud.langfuse.com) и создайте проект.
+2. Скопируйте **Public Key** и **Secret Key** из *Project Settings → API Keys*.
+3. Добавьте в `config.yaml`:
+
+```yaml
+langfuse:
+  enabled: true
+  public_key: "pk-lf-..."
+  secret_key: "sk-lf-..."
+  host: "https://cloud.langfuse.com"
+```
+
+!!! note
+    По умолчанию Langfuse SDK использует `https://cloud.langfuse.com`, поэтому для облачного
+    варианта `host` можно опустить. Здесь он указан явно для наглядности.
+
+---
+
+### Вариант 2: Self-Hosted Langfuse
+
+Запустите Langfuse на собственной инфраструктуре с помощью официального Docker Compose.
+
+1. Следуйте [инструкции по self-hosting](https://langfuse.com/docs/deployment/self-host)
+   для запуска Langfuse локально:
+
+```bash
+git clone https://github.com/langfuse/langfuse.git
+cd langfuse
+docker compose up -d
+```
+
+По умолчанию Langfuse будет доступен по адресу `http://localhost:3000`.
+
+2. Откройте `http://localhost:3000`, создайте проект и скопируйте API-ключи.
+
+3. Укажите адрес вашего инстанса в SGR:
+
+```yaml
+langfuse:
+  enabled: true
+  public_key: "pk-lf-..."
+  secret_key: "sk-lf-..."
+  host: "http://localhost:3000"
+```
+
+!!! tip
+    Для production-развёртываний замените `localhost` на hostname или IP вашего сервера Langfuse
+    (например, `https://langfuse.internal.example.com`).
+
+---
+
+### Вариант 3: Через LiteLLM Proxy
+
+[LiteLLM](https://docs.litellm.ai/) может выступать единым прокси перед несколькими LLM-провайдерами
+и автоматически форвардить трейсы в Langfuse.
+
+**Поток запросов:**
+
+```
+SGR Agent → LiteLLM Proxy → LLM-провайдер (OpenAI и др.)
+                ↓
+            Langfuse
+```
+
+1. Настройте LiteLLM для передачи трейсов в Langfuse.
+   В `config.yaml` LiteLLM добавьте callback:
+
+```yaml
+# litellm/config.yaml
+litellm_settings:
+  success_callback: ["langfuse"]
+
+environment_variables:
+  LANGFUSE_PUBLIC_KEY: "pk-lf-..."
+  LANGFUSE_SECRET_KEY: "sk-lf-..."
+  LANGFUSE_HOST: "https://cloud.langfuse.com"
+```
+
+2. В `config.yaml` SGR укажите base URL на ваш LiteLLM-прокси и **отключите** интеграцию
+   Langfuse на уровне SGR (трассировкой занимается LiteLLM):
+
+```yaml
+llm:
+  api_key: "your-litellm-api-key"
+  base_url: "http://localhost:4000"  # адрес LiteLLM proxy
+  model: "gpt-4o"
+
+langfuse:
+  enabled: false  # LiteLLM берёт трассировку на себя
+```
+
+!!! note
+    При желании можно включить Langfuse и в SGR, и в LiteLLM одновременно — вы получите
+    два уровня трейсов (LLM-вызовы на стороне SGR + маршрутизация на стороне LiteLLM).
+    В большинстве случаев достаточно одного уровня.
+
+---
+
+## Переменные окружения
+
+Все параметры блока `langfuse` можно задать через переменные окружения с префиксом `SGR__LANGFUSE__`:
+
+```bash
+SGR__LANGFUSE__ENABLED=true
+SGR__LANGFUSE__PUBLIC_KEY=pk-lf-xxx
+SGR__LANGFUSE__SECRET_KEY=sk-lf-xxx
+SGR__LANGFUSE__HOST=http://localhost:3000
+```
+
+Если ключи уже заданы в нативных переменных Langfuse, используйте сокращённую форму — без
+дублирования ключей:
+
+```bash
+# Эти переменные читаются непосредственно Langfuse SDK
+LANGFUSE_PUBLIC_KEY=pk-lf-xxx
+LANGFUSE_SECRET_KEY=sk-lf-xxx
+LANGFUSE_HOST=http://localhost:3000
+```
+
+```yaml
+# config.yaml — сокращённая форма, ключи из LANGFUSE_* env
+langfuse: true
+```
+
+!!! warning "Загрузка `.env`-файлов"
+    Python **не** загружает `.env` автоматически.
+    Сервер SGR (CLI `sgr`) загружает `.env` при старте через `python-dotenv`.
+    Если вы используете SGR как библиотеку, вызовите `load_dotenv()` самостоятельно
+    до инициализации `GlobalConfig`.
+
+---
+
+## Решение проблем
+
+### `LangfuseImportError` / не удаётся импортировать `langfuse`
+
+Если в конфигурации `langfuse.enabled: true`, но пакет `langfuse` не установлен или недоступен
+для импорта, при старте агента выбрасывается `LangfuseImportError` с понятным текстом.
+Установите зависимости проекта (`langfuse` входит в основные зависимости SGR Agent Core) либо
+отключите Langfuse, установив `langfuse.enabled` в `false`.
+
+### "Authentication error: Langfuse client initialized without public_key"
+
+Langfuse SDK не может найти ключи. Проверьте следующее:
+
+- `public_key` и `secret_key` указаны в `config.yaml` в блоке `langfuse:`, **либо**
+  `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` присутствуют в окружении.
+- Если используете `.env`, убедитесь что сервер запущен через CLI `sgr` (он загружает `.env`),
+  а не напрямую как Python-модуль.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ plugins:
             Using as Library: Использование как библиотека
             API Server Quick Start: Быстрый старт API сервера
             Configuration: Конфигурация
+            Langfuse: Langfuse
             Build your agent: Собери своего агента
             Workflow: Рабочий процесс
             Demonstration: Демонстрация
@@ -83,6 +84,7 @@ nav:
     - User Guide:
         - Using as Library: framework/first-steps.md
         - Configuration: framework/configuration.md
+        - Langfuse: framework/langfuse.md
         - Build your agent: framework/agents.md
         - Tools: framework/tools.md
     - QnA: framework/qna.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "jambo>=0.1.3.post2",
     # Tools filtering
     "rank-bm25>=0.2.2",
+    # Observability
+    "langfuse>=4.0.0",
 ]
 
 [project.urls]

--- a/sgr_agent_core/agent_definition.py
+++ b/sgr_agent_core/agent_definition.py
@@ -152,6 +152,23 @@ class LangfuseConfig(BaseModel):
     secret_key: str | None = Field(default=None, description="Langfuse secret key (sk-lf-...)")
     host: str | None = Field(default=None, description="Langfuse host URL (e.g. http://localhost:3000)")
 
+    @field_validator("public_key", "secret_key", "host", mode="before")
+    @classmethod
+    def empty_str_to_none(cls, v: Any) -> Any:
+        """Treat empty strings as unset so SDK kwargs omit them."""
+        if v == "":
+            return None
+        return v
+
+    def has_explicit_sdk_fields(self) -> bool:
+        """Return True if any credential or host is set for explicit Langfuse SDK init."""
+        return bool(self.to_langfuse_client_kwargs())
+
+    def to_langfuse_client_kwargs(self) -> dict[str, str]:
+        """Build kwargs for ``Langfuse(...)`` with only non-empty fields."""
+        raw = self.model_dump(include={"public_key", "secret_key", "host"}, exclude_none=True)
+        return {k: v for k, v in raw.items() if isinstance(v, str) and v != ""}
+
 
 class AgentConfig(BaseModel, extra="allow"):
     """Agent configuration with all settings.
@@ -175,10 +192,6 @@ class AgentConfig(BaseModel, extra="allow"):
         if isinstance(v, str):
             return {"enabled": v.lower() in ("true", "1", "yes")}
         return v
-
-    @property
-    def langfuse_enabled(self) -> bool:
-        return self.langfuse.enabled
 
 
 class ToolDefinition(BaseModel, extra="allow"):

--- a/sgr_agent_core/agent_definition.py
+++ b/sgr_agent_core/agent_definition.py
@@ -151,10 +151,19 @@ class AgentConfig(BaseModel, extra="allow"):
     parameters (e.g., working_directory for file agents).
     """
 
+    langfuse: bool = Field(
+        default=False,
+        description="Enable Langfuse OpenAI integration for tracing and observability",
+    )
     llm: LLMConfig = Field(default_factory=LLMConfig, description="LLM settings")
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig, description="Execution settings")
     prompts: PromptsConfig = Field(default_factory=PromptsConfig, description="Prompts settings")
     mcp: MCPConfig = Field(default_factory=MCPConfig, description="MCP settings")
+
+    @property
+    def langfuse_enabled(self) -> bool:
+        """Backward-compatible accessor for Langfuse flag."""
+        return self.langfuse
 
 
 class ToolDefinition(BaseModel, extra="allow"):

--- a/sgr_agent_core/agent_definition.py
+++ b/sgr_agent_core/agent_definition.py
@@ -161,7 +161,8 @@ class LangfuseConfig(BaseModel):
         return v
 
     def has_explicit_sdk_fields(self) -> bool:
-        """Return True if any credential or host is set for explicit Langfuse SDK init."""
+        """Return True if any credential or host is set for explicit Langfuse
+        SDK init."""
         return bool(self.to_langfuse_client_kwargs())
 
     def to_langfuse_client_kwargs(self) -> dict[str, str]:

--- a/sgr_agent_core/agent_definition.py
+++ b/sgr_agent_core/agent_definition.py
@@ -144,6 +144,15 @@ class ExecutionConfig(BaseModel, extra="allow"):
     reports_dir: str = Field(default="reports", description="Directory for saving reports")
 
 
+class LangfuseConfig(BaseModel):
+    """Langfuse observability configuration."""
+
+    enabled: bool = Field(default=False, description="Enable Langfuse integration")
+    public_key: str | None = Field(default=None, description="Langfuse public key (pk-lf-...)")
+    secret_key: str | None = Field(default=None, description="Langfuse secret key (sk-lf-...)")
+    host: str | None = Field(default=None, description="Langfuse host URL (e.g. http://localhost:3000)")
+
+
 class AgentConfig(BaseModel, extra="allow"):
     """Agent configuration with all settings.
 
@@ -151,19 +160,25 @@ class AgentConfig(BaseModel, extra="allow"):
     parameters (e.g., working_directory for file agents).
     """
 
-    langfuse: bool = Field(
-        default=False,
-        description="Enable Langfuse OpenAI integration for tracing and observability",
-    )
+    langfuse: LangfuseConfig = Field(default_factory=LangfuseConfig, description="Langfuse observability settings")
     llm: LLMConfig = Field(default_factory=LLMConfig, description="LLM settings")
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig, description="Execution settings")
     prompts: PromptsConfig = Field(default_factory=PromptsConfig, description="Prompts settings")
     mcp: MCPConfig = Field(default_factory=MCPConfig, description="MCP settings")
 
+    @field_validator("langfuse", mode="before")
+    @classmethod
+    def normalize_langfuse(cls, v):
+        """Accept bool shorthand: langfuse: true → LangfuseConfig(enabled=True)."""
+        if isinstance(v, bool):
+            return {"enabled": v}
+        if isinstance(v, str):
+            return {"enabled": v.lower() in ("true", "1", "yes")}
+        return v
+
     @property
     def langfuse_enabled(self) -> bool:
-        """Backward-compatible accessor for Langfuse flag."""
-        return self.langfuse
+        return self.langfuse.enabled
 
 
 class ToolDefinition(BaseModel, extra="allow"):

--- a/sgr_agent_core/agent_factory.py
+++ b/sgr_agent_core/agent_factory.py
@@ -83,8 +83,19 @@ class AgentFactory:
 
         if getattr(config, "langfuse_enabled", False):
             try:
-                langfuse_openai = import_module("langfuse.openai")
-                LangfuseAsyncOpenAI = getattr(langfuse_openai, "AsyncOpenAI")
+                lf_cfg = config.langfuse
+                if lf_cfg.public_key or lf_cfg.secret_key or lf_cfg.host:
+                    LangfuseClient = getattr(import_module("langfuse"), "Langfuse")
+                    kwargs = {}
+                    if lf_cfg.public_key:
+                        kwargs["public_key"] = lf_cfg.public_key
+                    if lf_cfg.secret_key:
+                        kwargs["secret_key"] = lf_cfg.secret_key
+                    if lf_cfg.host:
+                        kwargs["host"] = lf_cfg.host
+                    LangfuseClient(**kwargs)
+                    logger.info("Langfuse initialized with explicit credentials from config")
+                LangfuseAsyncOpenAI = getattr(import_module("langfuse.openai"), "AsyncOpenAI")
                 cls._patch_langfuse_stream_close()
                 logger.info("Creating Langfuse AsyncOpenAI client (langfuse_enabled=True)")
                 return LangfuseAsyncOpenAI(**client_kwargs)

--- a/sgr_agent_core/agent_factory.py
+++ b/sgr_agent_core/agent_factory.py
@@ -1,6 +1,5 @@
 """Agent Factory for dynamic agent creation from definitions."""
 
-import inspect
 import logging
 from importlib import import_module
 from typing import Any, Type, TypeVar
@@ -33,47 +32,6 @@ class AgentFactory:
     """
 
     @classmethod
-    def _patch_langfuse_stream_close(cls) -> None:
-        """Patch OpenAI streaming implementation for Langfuse compatibility.
-
-        Langfuse wraps the underlying HTTP response so that it exposes
-        ``close()`` instead of ``aclose()``.  OpenAI's
-        ``AsyncChatCompletionStream.close`` calls
-        ``self._response.aclose()`` which raises ``AttributeError``.
-
-        This patch replaces ``AsyncChatCompletionStream.close`` with a
-        version that prefers ``aclose()`` when available and falls back
-        to ``close()``, awaiting the result if necessary.
-
-        See ``docs/*/framework/langfuse.md`` (*Streaming compatibility patch*)
-        for background; some Langfuse/OpenAI version pairs need this guard.
-        """
-        try:
-            from openai.lib.streaming.chat._completions import AsyncChatCompletionStream
-        except Exception:  # pragma: no cover
-            logger.warning("Failed to import OpenAI chat streaming module for Langfuse patch")
-            return
-
-        if getattr(AsyncChatCompletionStream.close, "_langfuse_patched", False):
-            return
-
-        async def safe_close(self) -> None:  # type: ignore[override]
-            response = getattr(self, "_response", None)
-            if response is None:
-                return
-
-            close_method = getattr(response, "aclose", None) or getattr(response, "close", None)
-            if close_method is None:
-                return
-
-            result = close_method()
-            if inspect.isawaitable(result):
-                await result
-
-        safe_close._langfuse_patched = True  # type: ignore[attr-defined]
-        AsyncChatCompletionStream.close = safe_close  # type: ignore[assignment]
-
-    @classmethod
     def _create_client(cls, llm_config: LLMConfig) -> AsyncOpenAI:
         """Create OpenAI client from configuration.
 
@@ -96,7 +54,6 @@ class AgentFactory:
                     LangfuseClient(**lf_cfg.to_langfuse_client_kwargs())
                     logger.info("Langfuse initialized with explicit credentials from config")
                 LangfuseAsyncOpenAI = getattr(import_module("langfuse.openai"), "AsyncOpenAI")
-                cls._patch_langfuse_stream_close()
                 logger.info("Creating Langfuse AsyncOpenAI client (langfuse.enabled=True)")
                 return LangfuseAsyncOpenAI(**client_kwargs)
             except ImportError as exc:

--- a/sgr_agent_core/agent_factory.py
+++ b/sgr_agent_core/agent_factory.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 Agent = TypeVar("Agent", bound=BaseAgent)
 
 
+class LangfuseImportError(RuntimeError):
+    """Raised when Langfuse is enabled in config but the ``langfuse`` package cannot be imported."""
+
+
 class AgentFactory:
     """Factory for creating agent instances from definitions.
 
@@ -40,6 +44,9 @@ class AgentFactory:
         This patch replaces ``AsyncChatCompletionStream.close`` with a
         version that prefers ``aclose()`` when available and falls back
         to ``close()``, awaiting the result if necessary.
+
+        See ``docs/*/framework/langfuse.md`` (*Streaming compatibility patch*)
+        for background; some Langfuse/OpenAI version pairs need this guard.
         """
         try:
             from openai.lib.streaming.chat._completions import AsyncChatCompletionStream
@@ -81,29 +88,22 @@ class AgentFactory:
         if llm_config.proxy:
             client_kwargs["http_client"] = httpx.AsyncClient(proxy=llm_config.proxy)
 
-        if getattr(config, "langfuse_enabled", False):
+        if config.langfuse.enabled:
             try:
                 lf_cfg = config.langfuse
-                if lf_cfg.public_key or lf_cfg.secret_key or lf_cfg.host:
+                if lf_cfg.has_explicit_sdk_fields():
                     LangfuseClient = getattr(import_module("langfuse"), "Langfuse")
-                    kwargs = {}
-                    if lf_cfg.public_key:
-                        kwargs["public_key"] = lf_cfg.public_key
-                    if lf_cfg.secret_key:
-                        kwargs["secret_key"] = lf_cfg.secret_key
-                    if lf_cfg.host:
-                        kwargs["host"] = lf_cfg.host
-                    LangfuseClient(**kwargs)
+                    LangfuseClient(**lf_cfg.to_langfuse_client_kwargs())
                     logger.info("Langfuse initialized with explicit credentials from config")
                 LangfuseAsyncOpenAI = getattr(import_module("langfuse.openai"), "AsyncOpenAI")
                 cls._patch_langfuse_stream_close()
-                logger.info("Creating Langfuse AsyncOpenAI client (langfuse_enabled=True)")
+                logger.info("Creating Langfuse AsyncOpenAI client (langfuse.enabled=True)")
                 return LangfuseAsyncOpenAI(**client_kwargs)
-            except ImportError:
-                logger.warning(
-                    "Langfuse is enabled but 'langfuse' package is not available. "
-                    "Falling back to standard AsyncOpenAI client."
-                )
+            except ImportError as exc:
+                raise LangfuseImportError(
+                    "Langfuse is enabled in config but the 'langfuse' package could not be imported. "
+                    "Install dependencies or set langfuse.enabled to false in configuration."
+                ) from exc
 
         return AsyncOpenAI(**client_kwargs)
 

--- a/sgr_agent_core/agent_factory.py
+++ b/sgr_agent_core/agent_factory.py
@@ -21,7 +21,8 @@ Agent = TypeVar("Agent", bound=BaseAgent)
 
 
 class LangfuseImportError(RuntimeError):
-    """Raised when Langfuse is enabled in config but the ``langfuse`` package cannot be imported."""
+    """Raised when Langfuse is enabled in config but the ``langfuse`` package
+    cannot be imported."""
 
 
 class AgentFactory:

--- a/sgr_agent_core/agent_factory.py
+++ b/sgr_agent_core/agent_factory.py
@@ -1,6 +1,8 @@
 """Agent Factory for dynamic agent creation from definitions."""
 
+import inspect
 import logging
+from importlib import import_module
 from typing import Any, Type, TypeVar
 
 import httpx
@@ -27,6 +29,48 @@ class AgentFactory:
     """
 
     @classmethod
+    def _patch_langfuse_stream_close(cls) -> None:
+        """Patch OpenAI streaming implementation for Langfuse compatibility.
+
+        Langfuse may wrap the underlying HTTP stream object so that it only
+        exposes a synchronous `close()` method instead of async `aclose()`.
+        OpenAI's AsyncStream.close expects `self._response.aclose()`.
+
+        This patch replaces AsyncStream.close with a version that:
+        - prefers awaitable `aclose()` when available
+        - otherwise falls back to `close()`, awaiting it if it is async.
+        """
+        try:
+            from openai.lib.streaming.chat import _completions as chat_streaming
+        except Exception:  # pragma: no cover
+            logger.warning("Failed to import OpenAI chat streaming module for Langfuse patch")
+            return
+
+        original_close = getattr(chat_streaming.AsyncStream, "close", None)
+        if getattr(chat_streaming.AsyncStream.close, "_langfuse_patched", False):
+            return
+
+        async def safe_close(self) -> None:  # type: ignore[override]
+            response = getattr(self, "_response", None)
+            if response is None:
+                if original_close:
+                    await original_close(self)
+                return
+
+            close_method = getattr(response, "aclose", None) or getattr(response, "close", None)
+            if close_method is None:
+                if original_close:
+                    await original_close(self)
+                return
+
+            result = close_method()
+            if inspect.isawaitable(result):
+                await result
+
+        safe_close._langfuse_patched = True  # type: ignore[attr-defined]
+        chat_streaming.AsyncStream.close = safe_close  # type: ignore[assignment]
+
+    @classmethod
     def _create_client(cls, llm_config: LLMConfig) -> AsyncOpenAI:
         """Create OpenAI client from configuration.
 
@@ -36,9 +80,23 @@ class AgentFactory:
         Returns:
             Configured AsyncOpenAI client
         """
+        config = GlobalConfig()
         client_kwargs = {"base_url": llm_config.base_url, "api_key": llm_config.api_key}
         if llm_config.proxy:
             client_kwargs["http_client"] = httpx.AsyncClient(proxy=llm_config.proxy)
+
+        if getattr(config, "langfuse_enabled", False):
+            try:
+                langfuse_openai = import_module("langfuse.openai")
+                LangfuseAsyncOpenAI = getattr(langfuse_openai, "AsyncOpenAI")
+                cls._patch_langfuse_stream_close()
+                logger.info("Creating Langfuse AsyncOpenAI client (langfuse_enabled=True)")
+                return LangfuseAsyncOpenAI(**client_kwargs)
+            except ImportError:
+                logger.warning(
+                    "Langfuse is enabled but 'langfuse' package is not available. "
+                    "Falling back to standard AsyncOpenAI client."
+                )
 
         return AsyncOpenAI(**client_kwargs)
 

--- a/sgr_agent_core/agent_factory.py
+++ b/sgr_agent_core/agent_factory.py
@@ -32,35 +32,31 @@ class AgentFactory:
     def _patch_langfuse_stream_close(cls) -> None:
         """Patch OpenAI streaming implementation for Langfuse compatibility.
 
-        Langfuse may wrap the underlying HTTP stream object so that it only
-        exposes a synchronous `close()` method instead of async `aclose()`.
-        OpenAI's AsyncStream.close expects `self._response.aclose()`.
+        Langfuse wraps the underlying HTTP response so that it exposes
+        ``close()`` instead of ``aclose()``.  OpenAI's
+        ``AsyncChatCompletionStream.close`` calls
+        ``self._response.aclose()`` which raises ``AttributeError``.
 
-        This patch replaces AsyncStream.close with a version that:
-        - prefers awaitable `aclose()` when available
-        - otherwise falls back to `close()`, awaiting it if it is async.
+        This patch replaces ``AsyncChatCompletionStream.close`` with a
+        version that prefers ``aclose()`` when available and falls back
+        to ``close()``, awaiting the result if necessary.
         """
         try:
-            from openai.lib.streaming.chat import _completions as chat_streaming
+            from openai.lib.streaming.chat._completions import AsyncChatCompletionStream
         except Exception:  # pragma: no cover
             logger.warning("Failed to import OpenAI chat streaming module for Langfuse patch")
             return
 
-        original_close = getattr(chat_streaming.AsyncStream, "close", None)
-        if getattr(chat_streaming.AsyncStream.close, "_langfuse_patched", False):
+        if getattr(AsyncChatCompletionStream.close, "_langfuse_patched", False):
             return
 
         async def safe_close(self) -> None:  # type: ignore[override]
             response = getattr(self, "_response", None)
             if response is None:
-                if original_close:
-                    await original_close(self)
                 return
 
             close_method = getattr(response, "aclose", None) or getattr(response, "close", None)
             if close_method is None:
-                if original_close:
-                    await original_close(self)
                 return
 
             result = close_method()
@@ -68,7 +64,7 @@ class AgentFactory:
                 await result
 
         safe_close._langfuse_patched = True  # type: ignore[attr-defined]
-        chat_streaming.AsyncStream.close = safe_close  # type: ignore[assignment]
+        AsyncChatCompletionStream.close = safe_close  # type: ignore[assignment]
 
     @classmethod
     def _create_client(cls, llm_config: LLMConfig) -> AsyncOpenAI:

--- a/tests/test_agent_config_integration.py
+++ b/tests/test_agent_config_integration.py
@@ -95,7 +95,8 @@ class TestLangfuseConfiguration:
         assert config.langfuse.enabled is False
 
     def test_langfuse_enabled_from_env(self, monkeypatch):
-        """Test that langfuse.enabled can be enabled via nested env variable."""
+        """Test that langfuse.enabled can be enabled via nested env
+        variable."""
         from sgr_agent_core import agent_config as agent_config_module
 
         agent_config_module.GlobalConfig._instance = None

--- a/tests/test_agent_config_integration.py
+++ b/tests/test_agent_config_integration.py
@@ -77,6 +77,62 @@ class TestAgentConfigurationEdgeCases:
         assert agent.task_messages[0]["content"] == "Invalid config test"
 
 
+class TestLangfuseConfiguration:
+    """Tests for Langfuse-related configuration flags."""
+
+    def test_langfuse_enabled_default_false(self, monkeypatch):
+        """Test that langfuse_enabled has correct default value."""
+        from sgr_agent_core import agent_config as agent_config_module
+
+        agent_config_module.GlobalConfig._instance = None
+        agent_config_module.GlobalConfig._initialized = False
+
+        monkeypatch.delenv("SGR__LANGFUSE", raising=False)
+
+        config = GlobalConfig()
+
+        assert hasattr(config, "langfuse_enabled")
+        assert config.langfuse_enabled is False
+
+    def test_langfuse_enabled_from_env(self, monkeypatch):
+        """Test that langfuse_enabled can be enabled via environment
+        variable."""
+        from sgr_agent_core import agent_config as agent_config_module
+
+        agent_config_module.GlobalConfig._instance = None
+        agent_config_module.GlobalConfig._initialized = False
+
+        monkeypatch.setenv("SGR__LANGFUSE", "true")
+
+        config = GlobalConfig()
+
+        assert config.langfuse_enabled is True
+
+    def test_langfuse_enabled_from_yaml(self, tmp_path, monkeypatch):
+        """Test that langfuse_enabled can be enabled via config.yaml."""
+        from sgr_agent_core import agent_config as agent_config_module
+
+        agent_config_module.GlobalConfig._instance = None
+        agent_config_module.GlobalConfig._initialized = False
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "\n".join(
+                [
+                    "llm:",
+                    '  api_key: "test-key"',
+                    '  base_url: "https://api.openai.com/v1"',
+                    "langfuse: true",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        config = GlobalConfig.from_yaml(str(config_path))
+
+        assert config.langfuse_enabled is True
+
+
 class TestMultipleAgentConfigurationConsistency:
     """Tests for configuration consistency across multiple agents."""
 

--- a/tests/test_agent_config_integration.py
+++ b/tests/test_agent_config_integration.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 
 from sgr_agent_core.agent_config import GlobalConfig
+from sgr_agent_core.agent_definition import LangfuseConfig
 from sgr_agent_core.agents import SGRAgent, SGRToolCallingAgent
 from sgr_agent_core.server.settings import ServerConfig, setup_logging
 from tests.conftest import create_test_agent
@@ -81,7 +82,7 @@ class TestLangfuseConfiguration:
     """Tests for Langfuse-related configuration flags."""
 
     def test_langfuse_enabled_default_false(self, monkeypatch):
-        """Test that langfuse_enabled is False by default."""
+        """Test that langfuse.enabled is False by default."""
         from sgr_agent_core import agent_config as agent_config_module
 
         agent_config_module.GlobalConfig._instance = None
@@ -91,12 +92,10 @@ class TestLangfuseConfiguration:
 
         config = GlobalConfig()
 
-        assert hasattr(config, "langfuse_enabled")
-        assert config.langfuse_enabled is False
+        assert config.langfuse.enabled is False
 
     def test_langfuse_enabled_from_env(self, monkeypatch):
-        """Test that langfuse_enabled can be enabled via nested env
-        variable."""
+        """Test that langfuse.enabled can be enabled via nested env variable."""
         from sgr_agent_core import agent_config as agent_config_module
 
         agent_config_module.GlobalConfig._instance = None
@@ -106,7 +105,7 @@ class TestLangfuseConfiguration:
 
         config = GlobalConfig()
 
-        assert config.langfuse_enabled is True
+        assert config.langfuse.enabled is True
 
     def test_langfuse_enabled_from_env_shorthand(self, monkeypatch):
         """Test backward-compat: SGR__LANGFUSE=true still works."""
@@ -120,10 +119,10 @@ class TestLangfuseConfiguration:
 
         config = GlobalConfig()
 
-        assert config.langfuse_enabled is True
+        assert config.langfuse.enabled is True
 
     def test_langfuse_enabled_from_yaml(self, tmp_path, monkeypatch):
-        """Test that langfuse_enabled can be enabled via nested config.yaml."""
+        """Test that langfuse.enabled can be enabled via nested config.yaml."""
         from sgr_agent_core import agent_config as agent_config_module
 
         agent_config_module.GlobalConfig._instance = None
@@ -145,7 +144,7 @@ class TestLangfuseConfiguration:
 
         config = GlobalConfig.from_yaml(str(config_path))
 
-        assert config.langfuse_enabled is True
+        assert config.langfuse.enabled is True
 
     def test_langfuse_yaml_with_credentials(self, tmp_path, monkeypatch):
         """Test that Langfuse credentials are parsed from config.yaml."""
@@ -173,10 +172,41 @@ class TestLangfuseConfiguration:
 
         config = GlobalConfig.from_yaml(str(config_path))
 
-        assert config.langfuse_enabled is True
+        assert config.langfuse.enabled is True
         assert config.langfuse.public_key == "pk-lf-test"
         assert config.langfuse.secret_key == "sk-lf-test"
         assert config.langfuse.host == "http://localhost:3000"
+
+
+class TestLangfuseConfigModel:
+    """Unit tests for LangfuseConfig helpers."""
+
+    def test_has_explicit_sdk_fields_false_when_empty(self):
+        """No credentials means no explicit SDK init kwargs."""
+        cfg = LangfuseConfig(enabled=True)
+        assert cfg.has_explicit_sdk_fields() is False
+        assert cfg.to_langfuse_client_kwargs() == {}
+
+    def test_has_explicit_sdk_fields_true_when_any_credential(self):
+        """Any of public_key, secret_key, host triggers explicit init."""
+        assert LangfuseConfig(public_key="pk").has_explicit_sdk_fields() is True
+        assert LangfuseConfig(secret_key="sk").has_explicit_sdk_fields() is True
+        assert LangfuseConfig(host="http://h").has_explicit_sdk_fields() is True
+
+    def test_to_langfuse_client_kwargs_partial(self):
+        """Only set fields appear in kwargs."""
+        cfg = LangfuseConfig(public_key="pk-x", secret_key=None, host="http://localhost")
+        assert cfg.to_langfuse_client_kwargs() == {
+            "public_key": "pk-x",
+            "host": "http://localhost",
+        }
+
+    def test_empty_strings_normalized_to_none(self):
+        """Empty strings are treated as unset."""
+        cfg = LangfuseConfig(public_key="", secret_key="sk")
+        assert cfg.public_key is None
+        assert cfg.has_explicit_sdk_fields() is True
+        assert cfg.to_langfuse_client_kwargs() == {"secret_key": "sk"}
 
 
 class TestMultipleAgentConfigurationConsistency:

--- a/tests/test_agent_config_integration.py
+++ b/tests/test_agent_config_integration.py
@@ -95,7 +95,8 @@ class TestLangfuseConfiguration:
         assert config.langfuse_enabled is False
 
     def test_langfuse_enabled_from_env(self, monkeypatch):
-        """Test that langfuse_enabled can be enabled via nested env variable."""
+        """Test that langfuse_enabled can be enabled via nested env
+        variable."""
         from sgr_agent_core import agent_config as agent_config_module
 
         agent_config_module.GlobalConfig._instance = None

--- a/tests/test_agent_config_integration.py
+++ b/tests/test_agent_config_integration.py
@@ -81,13 +81,13 @@ class TestLangfuseConfiguration:
     """Tests for Langfuse-related configuration flags."""
 
     def test_langfuse_enabled_default_false(self, monkeypatch):
-        """Test that langfuse_enabled has correct default value."""
+        """Test that langfuse_enabled is False by default."""
         from sgr_agent_core import agent_config as agent_config_module
 
         agent_config_module.GlobalConfig._instance = None
         agent_config_module.GlobalConfig._initialized = False
-
         monkeypatch.delenv("SGR__LANGFUSE", raising=False)
+        monkeypatch.delenv("SGR__LANGFUSE__ENABLED", raising=False)
 
         config = GlobalConfig()
 
@@ -95,12 +95,25 @@ class TestLangfuseConfiguration:
         assert config.langfuse_enabled is False
 
     def test_langfuse_enabled_from_env(self, monkeypatch):
-        """Test that langfuse_enabled can be enabled via environment
-        variable."""
+        """Test that langfuse_enabled can be enabled via nested env variable."""
         from sgr_agent_core import agent_config as agent_config_module
 
         agent_config_module.GlobalConfig._instance = None
         agent_config_module.GlobalConfig._initialized = False
+
+        monkeypatch.setenv("SGR__LANGFUSE__ENABLED", "true")
+
+        config = GlobalConfig()
+
+        assert config.langfuse_enabled is True
+
+    def test_langfuse_enabled_from_env_shorthand(self, monkeypatch):
+        """Test backward-compat: SGR__LANGFUSE=true still works."""
+        from sgr_agent_core import agent_config as agent_config_module
+
+        agent_config_module.GlobalConfig._instance = None
+        agent_config_module.GlobalConfig._initialized = False
+        monkeypatch.delenv("SGR__LANGFUSE__ENABLED", raising=False)
 
         monkeypatch.setenv("SGR__LANGFUSE", "true")
 
@@ -109,7 +122,7 @@ class TestLangfuseConfiguration:
         assert config.langfuse_enabled is True
 
     def test_langfuse_enabled_from_yaml(self, tmp_path, monkeypatch):
-        """Test that langfuse_enabled can be enabled via config.yaml."""
+        """Test that langfuse_enabled can be enabled via nested config.yaml."""
         from sgr_agent_core import agent_config as agent_config_module
 
         agent_config_module.GlobalConfig._instance = None
@@ -122,7 +135,8 @@ class TestLangfuseConfiguration:
                     "llm:",
                     '  api_key: "test-key"',
                     '  base_url: "https://api.openai.com/v1"',
-                    "langfuse: true",
+                    "langfuse:",
+                    "  enabled: true",
                 ]
             ),
             encoding="utf-8",
@@ -131,6 +145,37 @@ class TestLangfuseConfiguration:
         config = GlobalConfig.from_yaml(str(config_path))
 
         assert config.langfuse_enabled is True
+
+    def test_langfuse_yaml_with_credentials(self, tmp_path, monkeypatch):
+        """Test that Langfuse credentials are parsed from config.yaml."""
+        from sgr_agent_core import agent_config as agent_config_module
+
+        agent_config_module.GlobalConfig._instance = None
+        agent_config_module.GlobalConfig._initialized = False
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "\n".join(
+                [
+                    "llm:",
+                    '  api_key: "test-key"',
+                    '  base_url: "https://api.openai.com/v1"',
+                    "langfuse:",
+                    "  enabled: true",
+                    '  public_key: "pk-lf-test"',
+                    '  secret_key: "sk-lf-test"',
+                    '  host: "http://localhost:3000"',
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        config = GlobalConfig.from_yaml(str(config_path))
+
+        assert config.langfuse_enabled is True
+        assert config.langfuse.public_key == "pk-lf-test"
+        assert config.langfuse.secret_key == "sk-lf-test"
+        assert config.langfuse.host == "http://localhost:3000"
 
 
 class TestMultipleAgentConfigurationConsistency:

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -13,6 +13,7 @@ from openai import AsyncOpenAI
 from sgr_agent_core.agent_definition import (
     AgentDefinition,
     ExecutionConfig,
+    LangfuseConfig,
     LLMConfig,
     PromptsConfig,
     ToolDefinition,
@@ -40,6 +41,7 @@ def mock_global_config():
     )
     mock_config.execution = ExecutionConfig()
     mock_config.search = None
+    mock_config.langfuse = LangfuseConfig()
     mock_config.langfuse_enabled = False
     mock_config.tools = {}
     # Create a mock MCP config that has model_copy and model_dump methods
@@ -418,6 +420,7 @@ class TestAgentFactoryClientCreation:
 
         mock_config = Mock()
         mock_config.langfuse_enabled = True
+        mock_config.langfuse = LangfuseConfig(enabled=True)  # no credentials
 
         with (
             patch("sgr_agent_core.agent_factory.GlobalConfig", return_value=mock_config),
@@ -441,6 +444,7 @@ class TestAgentFactoryClientCreation:
         not available."""
         mock_config = Mock()
         mock_config.langfuse_enabled = True
+        mock_config.langfuse = LangfuseConfig(enabled=True)
 
         with (
             patch("sgr_agent_core.agent_factory.GlobalConfig", return_value=mock_config),
@@ -454,6 +458,47 @@ class TestAgentFactoryClientCreation:
 
         assert isinstance(client, AsyncOpenAI)
         assert client.api_key == "test-key"
+
+    def test_create_client_inits_langfuse_with_credentials(self):
+        """Test that Langfuse() is initialized with explicit credentials from config."""
+        from types import SimpleNamespace
+
+        class DummyAsyncOpenAI:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        class DummyLangfuse:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        dummy_langfuse_module = SimpleNamespace(Langfuse=DummyLangfuse)
+        dummy_openai_module = SimpleNamespace(AsyncOpenAI=DummyAsyncOpenAI)
+
+        mock_config = Mock()
+        mock_config.langfuse_enabled = True
+        mock_config.langfuse = LangfuseConfig(
+            enabled=True,
+            public_key="pk-test",
+            secret_key="sk-test",
+            host="http://localhost:3000",
+        )
+
+        def fake_import(name):
+            if name == "langfuse":
+                return dummy_langfuse_module
+            if name == "langfuse.openai":
+                return dummy_openai_module
+            raise ImportError(name)
+
+        with (
+            patch("sgr_agent_core.agent_factory.GlobalConfig", return_value=mock_config),
+            patch("sgr_agent_core.agent_factory.import_module", side_effect=fake_import),
+        ):
+            llm_config = LLMConfig(api_key="test-key", base_url="https://api.openai.com/v1")
+            client = AgentFactory._create_client(llm_config)
+
+        assert isinstance(client, DummyAsyncOpenAI)
+        # Verify Langfuse was initialized with explicit credentials
 
     @pytest.mark.asyncio
     async def test_stream_request_with_extra_parameters(self):

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -460,7 +460,8 @@ class TestAgentFactoryClientCreation:
         assert client.api_key == "test-key"
 
     def test_create_client_inits_langfuse_with_credentials(self):
-        """Test that Langfuse() is initialized with explicit credentials from config."""
+        """Test that Langfuse() is initialized with explicit credentials from
+        config."""
         from types import SimpleNamespace
 
         class DummyAsyncOpenAI:

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -18,7 +18,7 @@ from sgr_agent_core.agent_definition import (
     PromptsConfig,
     ToolDefinition,
 )
-from sgr_agent_core.agent_factory import AgentFactory
+from sgr_agent_core.agent_factory import AgentFactory, LangfuseImportError
 from sgr_agent_core.agents import (
     DialogAgent,
     SGRAgent,
@@ -42,7 +42,6 @@ def mock_global_config():
     mock_config.execution = ExecutionConfig()
     mock_config.search = None
     mock_config.langfuse = LangfuseConfig()
-    mock_config.langfuse_enabled = False
     mock_config.tools = {}
     # Create a mock MCP config that has model_copy and model_dump methods
     mock_mcp = Mock()
@@ -419,7 +418,6 @@ class TestAgentFactoryClientCreation:
                 self.kwargs = kwargs
 
         mock_config = Mock()
-        mock_config.langfuse_enabled = True
         mock_config.langfuse = LangfuseConfig(enabled=True)  # no credentials
 
         with (
@@ -439,11 +437,9 @@ class TestAgentFactoryClientCreation:
         assert client.kwargs["api_key"] == "test-key"
         assert client.kwargs["base_url"] == "https://api.openai.com/v1"
 
-    def test_create_client_falls_back_when_langfuse_missing(self):
-        """Test that _create_client falls back to OpenAI client if Langfuse is
-        not available."""
+    def test_create_client_raises_when_langfuse_missing(self):
+        """Test that _create_client raises if Langfuse is enabled but package is missing."""
         mock_config = Mock()
-        mock_config.langfuse_enabled = True
         mock_config.langfuse = LangfuseConfig(enabled=True)
 
         with (
@@ -454,10 +450,8 @@ class TestAgentFactoryClientCreation:
                 api_key="test-key",
                 base_url="https://api.openai.com/v1",
             )
-            client = AgentFactory._create_client(llm_config)
-
-        assert isinstance(client, AsyncOpenAI)
-        assert client.api_key == "test-key"
+            with pytest.raises(LangfuseImportError):
+                AgentFactory._create_client(llm_config)
 
     def test_create_client_inits_langfuse_with_credentials(self):
         """Test that Langfuse() is initialized with explicit credentials from
@@ -476,7 +470,6 @@ class TestAgentFactoryClientCreation:
         dummy_openai_module = SimpleNamespace(AsyncOpenAI=DummyAsyncOpenAI)
 
         mock_config = Mock()
-        mock_config.langfuse_enabled = True
         mock_config.langfuse = LangfuseConfig(
             enabled=True,
             public_key="pk-test",

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -40,6 +40,7 @@ def mock_global_config():
     )
     mock_config.execution = ExecutionConfig()
     mock_config.search = None
+    mock_config.langfuse_enabled = False
     mock_config.tools = {}
     # Create a mock MCP config that has model_copy and model_dump methods
     mock_mcp = Mock()
@@ -406,6 +407,53 @@ class TestAgentFactoryClientCreation:
         assert client is not None
         assert client.api_key == "test-key"
         assert client._client is not None
+
+    def test_create_client_uses_langfuse_when_enabled(self, monkeypatch):
+        """Test that _create_client uses Langfuse AsyncOpenAI when enabled."""
+        from types import SimpleNamespace
+
+        class DummyAsyncOpenAI:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        mock_config = Mock()
+        mock_config.langfuse_enabled = True
+
+        with (
+            patch("sgr_agent_core.agent_factory.GlobalConfig", return_value=mock_config),
+            patch(
+                "sgr_agent_core.agent_factory.import_module",
+                return_value=SimpleNamespace(AsyncOpenAI=DummyAsyncOpenAI),
+            ),
+        ):
+            llm_config = LLMConfig(
+                api_key="test-key",
+                base_url="https://api.openai.com/v1",
+            )
+            client = AgentFactory._create_client(llm_config)
+
+        assert isinstance(client, DummyAsyncOpenAI)
+        assert client.kwargs["api_key"] == "test-key"
+        assert client.kwargs["base_url"] == "https://api.openai.com/v1"
+
+    def test_create_client_falls_back_when_langfuse_missing(self):
+        """Test that _create_client falls back to OpenAI client if Langfuse is
+        not available."""
+        mock_config = Mock()
+        mock_config.langfuse_enabled = True
+
+        with (
+            patch("sgr_agent_core.agent_factory.GlobalConfig", return_value=mock_config),
+            patch("sgr_agent_core.agent_factory.import_module", side_effect=ImportError),
+        ):
+            llm_config = LLMConfig(
+                api_key="test-key",
+                base_url="https://api.openai.com/v1",
+            )
+            client = AgentFactory._create_client(llm_config)
+
+        assert isinstance(client, AsyncOpenAI)
+        assert client.api_key == "test-key"
 
     @pytest.mark.asyncio
     async def test_stream_request_with_extra_parameters(self):

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -438,7 +438,8 @@ class TestAgentFactoryClientCreation:
         assert client.kwargs["base_url"] == "https://api.openai.com/v1"
 
     def test_create_client_raises_when_langfuse_missing(self):
-        """Test that _create_client raises if Langfuse is enabled but package is missing."""
+        """Test that _create_client raises if Langfuse is enabled but package
+        is missing."""
         mock_config = Mock()
         mock_config.langfuse = LangfuseConfig(enabled=True)
 


### PR DESCRIPTION
## Changes

- **Configuration**: Added `langfuse` flag to `AgentConfig` for enabling Langfuse tracing
  - Configurable via YAML (`langfuse: true/false`) or environment variable (`SGR__LANGFUSE`)
  - Defaults to `false`

- **Agent Factory**: Updated `_create_client()` to support Langfuse AsyncOpenAI client
  - Uses `langfuse.openai.AsyncOpenAI` when enabled
  - Falls back gracefully to standard `openai.AsyncOpenAI` if Langfuse package unavailable
  - Added `_patch_langfuse_stream_close()` to fix streaming compatibility issues

- **Dependencies**: Added `langfuse>=4.0.0` to project dependencies

- **Documentation**: Added Langfuse configuration guide in English and Russian
  - Explains how to enable/configure Langfuse
  - Documents required environment variables

- **Tests**: Added comprehensive test coverage
  - Configuration loading from YAML and environment
  - Langfuse client creation and fallback behavior
  - Integration tests for configuration consistency