### PR TITLE
Add opt-in Parallel MCP web search

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -73,12 +73,14 @@ tools:
     base_class: path.to.my.tools.CustomTool
   my_other_tool:
     base_class: "name_of_tool_class_in_registry"
-  # Search tools: configure search provider and API keys per tool
+  # Search tools: configure a provider per tool; Parallel needs no API key
   # (can be overridden per-agent in tools list)
   web_search_tool:
-    engine: "tavily"  # Search engine: "tavily" (default), "brave", or "perplexity"
-    api_key: "your-search-api-key-here"  # API key for the selected engine
-    # api_base_url: "https://custom-url"  # Optional, uses engine default
+    engine: "tavily"  # "tavily" (default), "brave", "perplexity", or "parallel"
+    api_key: "your-search-api-key-here"  # Required except when engine is "parallel"
+    # Parallel sends search objectives and queries to https://search.parallel.ai/mcp.
+    # This integration does not register its web_fetch tool, so requested URLs are not sent to Parallel.
+    # api_base_url: "https://custom-url"  # Optional for non-Parallel engines
     max_results: 12
     max_searches: 6
   extract_page_content_tool:

--- a/sgr_agent_core/agent_factory.py
+++ b/sgr_agent_core/agent_factory.py
@@ -18,6 +18,7 @@ from sgr_agent_core.services import AgentRegistry, MCP2ToolConverter, StreamingG
 from sgr_agent_core.skills import SkillRegistry, SkillsConfig, inject_referenced_skills
 from sgr_agent_core.stream import BaseStreamingGenerator, OpenAIStreamingGenerator
 from sgr_agent_core.tools.skill_tool import SkillTool
+from sgr_agent_core.tools.web_search_tool import ParallelWebSearchTool, WebSearchTool
 
 if TYPE_CHECKING:
     from sgr_agent_core.skills import BaseSkill
@@ -210,6 +211,10 @@ class AgentFactory:
             raise ValueError(error_msg)
         mcp_tools: list = await MCP2ToolConverter.build_tools_from_mcp(agent_def.mcp)
         tools, tool_configs = cls._resolve_tools_with_configs(agent_def.tools)
+        for index, tool in enumerate(tools):
+            if tool is WebSearchTool and tool_configs.get(tool.tool_name, {}).get("engine") == "parallel":
+                tools[index] = ParallelWebSearchTool
+                tool_configs[ParallelWebSearchTool.tool_name] = tool_configs.pop(tool.tool_name)
         tools.extend(mcp_tools)
 
         # Resolve skills and expose the use_skill tool when any are available.

--- a/sgr_agent_core/tools/__init__.py
+++ b/sgr_agent_core/tools/__init__.py
@@ -14,7 +14,7 @@ from sgr_agent_core.tools.generate_plan_tool import GeneratePlanTool
 from sgr_agent_core.tools.reasoning_tool import ReasoningTool
 from sgr_agent_core.tools.run_command_tool import RunCommandTool
 from sgr_agent_core.tools.skill_tool import SkillTool
-from sgr_agent_core.tools.web_search_tool import WebSearchConfig, WebSearchTool
+from sgr_agent_core.tools.web_search_tool import ParallelWebSearchTool, WebSearchConfig, WebSearchTool
 
 __all__ = [
     # Base classes
@@ -37,6 +37,7 @@ __all__ = [
     "ReasoningTool",
     "RunCommandTool",
     "SkillTool",
+    "ParallelWebSearchTool",
     "WebSearchConfig",
     "WebSearchTool",
 ]

--- a/sgr_agent_core/tools/web_search_tool.py
+++ b/sgr_agent_core/tools/web_search_tool.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal
 
 import httpx
-from pydantic import BaseModel, Field
+from fastmcp import Client
+from pydantic import BaseModel, Field, model_validator
 from tavily import AsyncTavilyClient
 
 from sgr_agent_core.base_tool import BaseTool
@@ -35,7 +37,7 @@ class WebSearchConfig(BaseModel, extra="allow"):
     Defines the search engine, credentials, and limits.
     """
 
-    engine: Literal["tavily", "brave", "perplexity"] = Field(
+    engine: Literal["tavily", "brave", "perplexity", "parallel"] = Field(
         default="tavily",
         description="Search engine provider to use",
     )
@@ -344,3 +346,128 @@ class WebSearchTool(BaseTool):
         context.searches_used += 1
         logger.debug(formatted_result)
         return formatted_result
+
+
+_PARALLEL_MCP_URL = "https://search.parallel.ai/mcp"
+
+
+class ParallelWebSearchTool(BaseTool):
+    """Search the web with Parallel Search MCP.
+
+    This tool is selected only when ``web_search_tool.engine`` is explicitly
+    set to ``parallel``. Search objectives and search queries are sent to
+    Parallel; URL fetching is not registered by this integration.
+    """
+
+    tool_name = "parallel_web_search"
+
+    objective: str | None = Field(
+        default=None,
+        description="Natural-language objective describing what the search should accomplish",
+    )
+    search_queries: list[str] | None = Field(
+        default=None,
+        description="Specific web search queries that support the objective",
+    )
+
+    @model_validator(mode="after")
+    def normalize_search_input(self):
+        objective = self.objective.strip() if self.objective else ""
+        queries = [query.strip() for query in (self.search_queries or []) if query.strip()]
+        if not objective and not queries:
+            raise ValueError("objective or at least one search query is required")
+        if not objective:
+            objective = queries[0]
+        if not queries:
+            queries = [objective]
+        self.objective = objective
+        self.search_queries = queries
+        return self
+
+    @staticmethod
+    def _validate_hosted_tools(tools: list[Any]) -> None:
+        advertised = {tool.name: tool.inputSchema for tool in tools}
+        search_schema = advertised.get("web_search")
+        fetch_schema = advertised.get("web_fetch")
+        if not search_schema or not fetch_schema:
+            raise RuntimeError("Parallel Search MCP did not advertise web_search and web_fetch")
+
+        search_properties = search_schema.get("properties", {})
+        objective_schema = search_properties.get("objective", {})
+        queries_schema = search_properties.get("search_queries", {})
+        fetch_urls_schema = fetch_schema.get("properties", {}).get("urls", {})
+        if (
+            objective_schema.get("type") != "string"
+            or queries_schema.get("type") != "array"
+            or queries_schema.get("items", {}).get("type") != "string"
+            or not {"objective", "search_queries"}.issubset(search_schema.get("required", []))
+            or fetch_urls_schema.get("type") != "array"
+            or fetch_urls_schema.get("items", {}).get("type") != "string"
+            or "urls" not in fetch_schema.get("required", [])
+        ):
+            raise RuntimeError("Parallel Search MCP advertised an unexpected tool schema")
+
+    @staticmethod
+    def _result_data(result: Any) -> dict[str, Any]:
+        structured = getattr(result, "structured_content", None)
+        if isinstance(structured, dict):
+            return structured
+        for content in getattr(result, "content", []):
+            text = getattr(content, "text", None)
+            if isinstance(text, str):
+                try:
+                    parsed = json.loads(text)
+                except (TypeError, ValueError):
+                    continue
+                if isinstance(parsed, dict):
+                    return parsed
+        raise RuntimeError("Parallel Search MCP returned no structured search result")
+
+    async def __call__(self, context: AgentContext, config: AgentConfig, **kwargs: Any) -> str:
+        payload = {"objective": self.objective, "search_queries": self.search_queries}
+        try:
+            async with Client(_PARALLEL_MCP_URL) as client:
+                self._validate_hosted_tools(await client.list_tools())
+                result = await client.call_tool("web_search", payload)
+        except Exception as exc:
+            logger.error("Parallel Search MCP request failed: %s", exc)
+            return f"Error: {exc}"
+
+        if getattr(result, "is_error", False):
+            raise RuntimeError("Parallel Search MCP returned a tool error")
+        data = self._result_data(result)
+        raw_results = data.get("results", data.get("search_results", []))
+        if not isinstance(raw_results, list):
+            raise RuntimeError("Parallel Search MCP returned malformed search results")
+
+        sources = []
+        for item in raw_results:
+            if not isinstance(item, dict) or not isinstance(item.get("url"), str) or not item["url"]:
+                continue
+            excerpts = item.get("excerpts")
+            if not isinstance(excerpts, list) or not all(isinstance(excerpt, str) for excerpt in excerpts):
+                raise RuntimeError("Parallel Search MCP returned malformed excerpts")
+            sources.append(
+                SourceData(
+                    number=0,
+                    title=item.get("title"),
+                    url=item["url"],
+                    snippet="\n".join(excerpts),
+                )
+            )
+
+        search_config = WebSearchConfig(**kwargs)
+        sources = sources[: search_config.max_results]
+        sources = _rearrange_sources(sources, starting_number=len(context.sources) + 1)
+        for source in sources:
+            context.sources[source.url] = source
+        query = self.search_queries[0]
+        search_result = SearchResult(query=query, citations=sources, timestamp=datetime.now())
+        context.searches.append(search_result)
+        context.searches_used += 1
+
+        formatted = f"Search Objective: {self.objective}\nSearch Queries: {', '.join(self.search_queries)}\n\n"
+        formatted += "Search Results (titles, links, excerpts):\n\n"
+        for source in sources:
+            formatted += f"{source}\n{source.snippet}\n\n"
+        return formatted

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -4,6 +4,7 @@ This module contains tests for AgentFactory and dynamic agent
 instantiation.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -26,8 +27,9 @@ from sgr_agent_core.agents import (
     ToolCallingAgent,
 )
 from sgr_agent_core.base_agent import BaseAgent
+from sgr_agent_core.models import AgentContext
 from sgr_agent_core.stream import OpenAIStreamingGenerator, OpenWebUIStreamingGenerator
-from sgr_agent_core.tools import BaseTool, ReasoningTool, RunCommandTool
+from sgr_agent_core.tools import BaseTool, ParallelWebSearchTool, ReasoningTool, RunCommandTool, WebSearchTool
 
 
 def mock_global_config():
@@ -1097,3 +1099,161 @@ class TestAgentFactoryDefinitionsList:
 
             assert len(definitions) == 0
             assert definitions == []
+
+
+class FakeParallelMCPClient:
+    """Faithful local fake for the hosted Parallel Search MCP contract."""
+
+    instances = []
+    fail_to_connect = False
+
+    def __init__(self, url):
+        assert url == "https://search.parallel.ai/mcp"
+        self.closed = False
+        self.calls = []
+        type(self).instances.append(self)
+
+    async def __aenter__(self):
+        if self.fail_to_connect:
+            raise OSError("vendor unavailable")
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.closed = True
+
+    async def list_tools(self):
+        return [
+            SimpleNamespace(
+                name="web_search",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "objective": {"type": "string"},
+                        "search_queries": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["objective", "search_queries"],
+                    "additionalProperties": False,
+                },
+            ),
+            SimpleNamespace(
+                name="web_fetch",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"urls": {"type": "array", "items": {"type": "string"}}},
+                    "required": ["urls"],
+                    "additionalProperties": False,
+                },
+            ),
+        ]
+
+    async def call_tool(self, name, arguments):
+        assert name == "web_search"
+        assert set(arguments) == {"objective", "search_queries"}
+        assert isinstance(arguments["objective"], str) and arguments["objective"]
+        assert isinstance(arguments["search_queries"], list) and arguments["search_queries"]
+        assert all(isinstance(query, str) and query for query in arguments["search_queries"])
+        self.calls.append((name, arguments))
+        return SimpleNamespace(
+            is_error=False,
+            structured_content={
+                "results": [
+                    {
+                        "url": "https://example.com/result",
+                        "title": None,
+                        "excerpts": ["First excerpt", "Second excerpt"],
+                    }
+                ]
+            },
+            content=[],
+        )
+
+
+async def _create_parallel_agent():
+    agent_def = AgentDefinition(
+        name="sgr_agent",
+        base_class=SGRAgent,
+        tools=["reasoningtool", {"web_search_tool": {"engine": "parallel"}}],
+        llm={"api_key": "test-key", "base_url": "https://api.openai.com/v1"},
+        prompts={
+            "system_prompt_str": "Test",
+            "initial_user_request_str": "Test",
+            "clarification_response_str": "Test",
+        },
+        execution={},
+    )
+    return await AgentFactory.create(
+        agent_def,
+        task_messages=[{"role": "user", "content": "private user request"}],
+    )
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_objective", "expected_queries"),
+    [
+        ({"objective": "Find current release"}, "Find current release", ["Find current release"]),
+        ({"search_queries": ["sgr release notes"]}, "sgr release notes", ["sgr release notes"]),
+        (
+            {"objective": "Compare releases", "search_queries": ["sgr v1", "sgr v2"]},
+            "Compare releases",
+            ["sgr v1", "sgr v2"],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_parallel_search_complete_factory_and_invocation(arguments, expected_objective, expected_queries):
+    FakeParallelMCPClient.instances.clear()
+    FakeParallelMCPClient.fail_to_connect = False
+    with (
+        patch("sgr_agent_core.agent_factory.MCP2ToolConverter.build_tools_from_mcp", return_value=[]),
+        patch("sgr_agent_core.tools.web_search_tool.Client", FakeParallelMCPClient),
+        mock_global_config(),
+    ):
+        agent = await _create_parallel_agent()
+        assert ParallelWebSearchTool in agent.toolkit
+        assert ReasoningTool in agent.toolkit
+        assert WebSearchTool not in agent.toolkit
+
+        schema = ParallelWebSearchTool.model_json_schema()["properties"]
+        assert schema["objective"]["anyOf"][0]["type"] == "string"
+        assert schema["search_queries"]["anyOf"][0] == {
+            "items": {"type": "string"},
+            "type": "array",
+        }
+
+        tool = ParallelWebSearchTool(**arguments)
+        context = AgentContext(custom_context={"private": "do not send"})
+        result = await tool(context, agent.config, **agent.tool_configs[tool.tool_name])
+
+    client = FakeParallelMCPClient.instances[-1]
+    assert client.closed is True
+    assert client.calls == [("web_search", {"objective": expected_objective, "search_queries": expected_queries})]
+    assert "private user request" not in str(client.calls)
+    assert "do not send" not in str(client.calls)
+    assert "First excerpt\nSecond excerpt" in result
+    assert context.sources["https://example.com/result"].title is None
+    assert context.sources["https://example.com/result"].snippet == "First excerpt\nSecond excerpt"
+
+
+@pytest.mark.asyncio
+async def test_parallel_vendor_unavailable_preserves_other_tools_and_state():
+    FakeParallelMCPClient.instances.clear()
+    FakeParallelMCPClient.fail_to_connect = True
+    with (
+        patch("sgr_agent_core.agent_factory.MCP2ToolConverter.build_tools_from_mcp", return_value=[]),
+        patch("sgr_agent_core.tools.web_search_tool.Client", FakeParallelMCPClient),
+        mock_global_config(),
+    ):
+        agent = await _create_parallel_agent()
+        context = AgentContext()
+        result = await ParallelWebSearchTool(objective="current facts")(context, agent.config)
+
+    assert result == "Error: vendor unavailable"
+    assert ReasoningTool in agent.toolkit
+    assert context.sources == {}
+    assert context.searches == []
+    assert context.searches_used == 0
+
+
+def test_parallel_is_explicit_opt_in_and_tavily_remains_default():
+    assert WebSearchTool.config_model().engine == "tavily"
+    assert ParallelWebSearchTool.tool_name != WebSearchTool.tool_name


### PR DESCRIPTION
## Why

This adds an optional anonymous web-search provider for research agents. It uses the hosted Parallel Search MCP endpoint at `https://search.parallel.ai/mcp` and requires no Parallel account or API key.

## Changes

- Add `parallel` as an explicit `web_search_tool` engine while keeping Tavily as the default and preserving Brave and Perplexity.
- Send only the tool-provided search objective and search query array to Parallel, normalizing objective-only and query-only calls to the hosted `web_search` schema.
- Validate the hosted `web_search` and `web_fetch` schemas, but register and invoke only `web_search`; requested URLs are therefore not sent to Parallel by this integration.
- Preserve result excerpts and nullable titles in the existing source model, and close each hosted MCP session after use.
- Document the opt-in configuration and third-party data routing.

## Validation

- `make format`
- `coverage run -m pytest`
- `coverage report`
- `git diff --check`
- `git status --short`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.